### PR TITLE
Fix TinyMCE double initialization error

### DIFF
--- a/assets/js/tinymce-init.js
+++ b/assets/js/tinymce-init.js
@@ -58,12 +58,7 @@ document.addEventListener('DOMContentLoaded', function() {
             ...tinymceConfig
         });
         
-        // Also initialize specific ID if needed
-        if (document.getElementById('body')) {
-            tinymce.init({
-                selector: '#body',
-                ...tinymceConfig
-            });
-        }
+        // The main layout file, admin.php, handles the initialization for the #body element.
+        // This script will only handle other textareas with the .tinymce-editor class.
     }
 });


### PR DESCRIPTION
The TinyMCE rich text editor was being initialized multiple times on pages that used both the main layout and the tinymce-init.js script. This caused a JavaScript error, 'A custom element with name 'mce-autosize-textarea' has already been defined'.

The fix is to remove the redundant initialization for the '#body' element from assets/js/tinymce-init.js. The main layout, src/Views/Layouts/admin.php, is responsible for initializing the primary editor instance, while tinymce-init.js handles other textareas with the '.tinymce-editor' class. This ensures that the editor is only initialized once per element, resolving the error.