### PR TITLE
Fix: Correct multiple frontend and backend errors

### DIFF
--- a/admin/content-form.php
+++ b/admin/content-form.php
@@ -509,10 +509,12 @@ function validateContentData(array $data, ?int $excludeId = null): array
     </div>
 
     <script>
-    // Initialize TinyMCE
-    tinymce.init({
-        selector: '.tinymce-editor',
-        height: 400,
+    // Initialize TinyMCE, but only if it hasn't been initialized for this element already.
+    // This prevents conflicts if this form is loaded into a page that already has TinyMCE.
+    if (document.querySelector('.tinymce-editor') && (!tinymce.get('body'))) {
+        tinymce.init({
+            selector: '.tinymce-editor',
+            height: 400,
         menubar: false,
         plugins: [
             'advlist', 'autolink', 'lists', 'link', 'image', 'charmap',
@@ -533,6 +535,7 @@ function validateContentData(array $data, ?int $excludeId = null): array
             });
         }
     });
+    }
 
     // Auto-generate URL alias from title
     document.getElementById('title').addEventListener('input', function() {

--- a/src/Views/Admin/dashboard/index.php
+++ b/src/Views/Admin/dashboard/index.php
@@ -6,7 +6,7 @@
             <p class="text-gray-600">Welcome to your CMS admin panel</p>
             <?php if (!empty($current_user)): ?>
                 <p class="text-sm text-gray-500 mt-1">
-                    Last login: <?= $this->formatDate($current_user['created_at'] ?? null, 'M j, Y g:i A') ?>
+                    Last login: <?= $this->formatDate($current_user->getAttribute('created_at') ?? null, 'M j, Y g:i A') ?>
                 </p>
             <?php endif; ?>
         </div>


### PR DESCRIPTION
This commit addresses several issues found in the admin panel.

1.  **Fix TinyMCE re-initialization error:** The `mce-autosize-textarea` JavaScript error was caused by TinyMCE being initialized multiple times on the same element. This happened when the legacy `admin/content-form.php` page was loaded in a context where another TinyMCE initialization script (from the main admin layout) was also present.

    The fix is to add a defensive check in `admin/content-form.php` to ensure TinyMCE is only initialized if an editor instance for the target element doesn't already exist.

2.  **Fix dashboard error with user object:** The admin dashboard was throwing an error (`Cannot use object of type CMS\Models\User as array`) because it was trying to access properties on the `User` model object using array syntax (e.g., `$current_user['created_at']`).

    The fix is to change the access method to use the model's `getAttribute()` method (e.g., `$current_user->getAttribute('created_at')`), which is the correct way to interact with the application's models. This resolves a critical error that would occur after a successful user login.